### PR TITLE
Update to core22 and add observer plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bandwhich
-base: core18
+base: core22
 adopt-info: bandwhich
 summary: Terminal bandwidth utilization tool
 description: 
@@ -11,15 +11,11 @@ confinement: strict
 parts:
   bandwhich:
     plugin: rust
-    rust-revision: "1.70.0"
     source: https://github.com/imsnif/bandwhich.git
     #source-tag: 0.20.0
-    build-packages:
-    - build-essential
-    - cargo
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=0).$(git rev-parse --short HEAD)
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=0).$(git rev-parse --short HEAD)
 apps:
   bandwhich:
     command: bin/bandwhich
@@ -28,3 +24,6 @@ apps:
     - network-bind
     - network-control
     - network-status
+    - system-observe
+    - mount-observe
+    - log-observe


### PR DESCRIPTION
Updated to use the snapcraft core22 rust plugin. Also add the system-,
mount- and log-observe plugins to allow process names to be displayed
and to prevent apparmor denials.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>